### PR TITLE
Changed go uuid package to point to v1 tag not master

### DIFF
--- a/backend_test.go
+++ b/backend_test.go
@@ -7,7 +7,7 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/satori/go.uuid"
+	"gopkg.in/satori/go.uuid.v1"
 )
 
 func getBackends() []CeleryBackend {

--- a/gocelery_test.go
+++ b/gocelery_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 	"time"
 
-	uuid "github.com/satori/go.uuid"
+	"gopkg.in/satori/go.uuid.v1"
 )
 
 func multiply(a int, b int) int {

--- a/message.go
+++ b/message.go
@@ -8,7 +8,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/satori/go.uuid"
+	"gopkg.in/satori/go.uuid.v1"
 )
 
 // CeleryMessage is actual message to be sent to Redis

--- a/worker_test.go
+++ b/worker_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/satori/go.uuid"
+	"gopkg.in/satori/go.uuid.v1"
 )
 
 // add is test task method


### PR DESCRIPTION
Solution according to the rants of developers on https://github.com/satori/go.uuid/issues/66.

> Software changes.
> 
> (•_•)
> ( •_•)>⌐■-■
> (⌐■_■)
> 
> Deal with it.